### PR TITLE
fix if Scrcpy path set to not end with \,tip scrcpy not found.

### DIFF
--- a/src/main/kotlin/model/command/factory/ScrcpyCommandFactory.kt
+++ b/src/main/kotlin/model/command/factory/ScrcpyCommandFactory.kt
@@ -1,6 +1,7 @@
 package model.command.factory
 
 import model.entity.Device
+import java.io.File
 
 class ScrcpyCommandFactory(
     override val path: String? = null
@@ -9,7 +10,11 @@ class ScrcpyCommandFactory(
     override fun create(data: Device): List<String> {
         return buildList {
             if (path != null) {
-                add("$path$COMMAND_NAME")
+                if (path.endsWith(File.separator)) {
+                    add("$path$COMMAND_NAME")
+                } else {
+                    add("$path${File.separator}$COMMAND_NAME")
+                }
             } else {
                 add(COMMAND_NAME)
             }
@@ -29,7 +34,11 @@ class ScrcpyCommandFactory(
     override fun createHelp(): List<String> {
         return buildList {
             if (path != null) {
-                add("$path$COMMAND_NAME")
+                if (path.endsWith(File.separator)) {
+                    add("$path$COMMAND_NAME")
+                } else {
+                    add("$path${File.separator}$COMMAND_NAME")
+                }
             } else {
                 add(COMMAND_NAME)
             }


### PR DESCRIPTION
thanks develop this useful tool, that would be  using Scrcpy more easy.
 I today try it, found set my Scrcpy install path `D:\MyDocuments\Desktop\reverse\toolsApk\scrcpy-win64-v1.20` to it, but also tip not found scrcpy command. 
i also try `D:\MyDocuments\Desktop\reverse\toolsApk\scrcpy-win64-v1.20\scrcpy-console.bat` ,`D:\MyDocuments\Desktop\reverse\toolsApk\scrcpy-win64-v1.20\scrcpy-noconsole.vbs` , the same thing, 
I can't find any documentation about Scrcpy path either, 

Now I fixed it, whether the path ends with \ or not, it will work normally.