### PR TITLE
Added window title

### DIFF
--- a/src/main/kotlin/view/MainWindow.kt
+++ b/src/main/kotlin/view/MainWindow.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.WindowState
 import view.resource.Colors
 import view.resource.Images
+import view.resource.Strings
 
 @Composable
 fun MainWindow(
@@ -22,6 +23,7 @@ fun MainWindow(
     Window(
         onCloseRequest = onCloseRequest,
         state = state,
+        title = Strings.APP_NAME,
         resizable = false,
         undecorated = true,
         transparent = true,


### PR DESCRIPTION
First of all thanks for very handy tool and a good example of a desktop compose app.

Very simple change to add a window title which is shown on some scenarios. See below Windows 10 small taskbar with labels shown. 

Without title.
![Without title](https://user-images.githubusercontent.com/14851039/193423758-4347e63e-27f5-45ed-bc0b-0bb243c3ad4a.PNG)

With title.
![With title](https://user-images.githubusercontent.com/14851039/193423755-3d0a69ea-5cc9-41d9-a200-c5d5d1982645.PNG)

Thanks.