### PR TITLE
Made tests be platform independent

### DIFF
--- a/src/test/kotlin/model/command/AdbCommandCreatorTest.kt
+++ b/src/test/kotlin/model/command/AdbCommandCreatorTest.kt
@@ -2,37 +2,38 @@ package model.command
 
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
+import java.io.File.separator as fileSeparator
 
 class AdbCommandCreatorTest : StringSpec(
     {
         "create" {
-            val factory = AdbCommandCreator(path = "test/")
-            factory.create() shouldBe listOf("test/adb")
+            val factory = AdbCommandCreator(path = "test$fileSeparator")
+            factory.create() shouldBe listOf("test${fileSeparator}adb")
 
             val factoryWhenNoSeparator = AdbCommandCreator(path = "test")
-            factoryWhenNoSeparator.create() shouldBe listOf("test/adb")
+            factoryWhenNoSeparator.create() shouldBe listOf("test${fileSeparator}adb")
         }
         "create_when_no_path_specified" {
             val factory = AdbCommandCreator()
             factory.create() shouldBe listOf("adb")
         }
         "create_help" {
-            val factory = AdbCommandCreator(path = "test/")
-            factory.createHelp() shouldBe listOf("test/adb", "--help")
+            val factory = AdbCommandCreator(path = "test$fileSeparator")
+            factory.createHelp() shouldBe listOf("test${fileSeparator}adb", "--help")
 
             val factoryWhenNoSeparator = AdbCommandCreator(path = "test")
-            factoryWhenNoSeparator.createHelp() shouldBe listOf("test/adb", "--help")
+            factoryWhenNoSeparator.createHelp() shouldBe listOf("test${fileSeparator}adb", "--help")
         }
         "create_help_when_no_path_specified" {
             val factory = AdbCommandCreator()
             factory.createHelp() shouldBe listOf("adb", "--help")
         }
         "create_start_server" {
-            val factory = AdbCommandCreator(path = "test/")
-            factory.createStartServer() shouldBe listOf("test/adb", "start-server")
+            val factory = AdbCommandCreator(path = "test$fileSeparator")
+            factory.createStartServer() shouldBe listOf("test${fileSeparator}adb", "start-server")
 
             val factoryWhenNoSeparator = AdbCommandCreator(path = "test")
-            factoryWhenNoSeparator.createStartServer() shouldBe listOf("test/adb", "start-server")
+            factoryWhenNoSeparator.createStartServer() shouldBe listOf("test${fileSeparator}adb", "start-server")
         }
         "create_start_server_when_no_path_specified" {
             val factory = AdbCommandCreator()

--- a/src/test/kotlin/model/command/ScrcpyCommandCreatorTest.kt
+++ b/src/test/kotlin/model/command/ScrcpyCommandCreatorTest.kt
@@ -3,18 +3,19 @@ package model.command
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import model.entity.Device
+import java.io.File.separator as fileSeparator
 
 class ScrcpyCommandCreatorTest : StringSpec({
     "create" {
-        val factory = ScrcpyCommandCreator(path = "test/")
+        val factory = ScrcpyCommandCreator(path = "test$fileSeparator")
         val factoryWhenNoSeparator = ScrcpyCommandCreator(path = "test")
 
         val device1 = Device.Context(
             Device(id = "DEVICE1", name = "NAME"), maxSize = null, maxFrameRate = null, bitrate = null
         )
-        factory.create(device1) shouldBe listOf("test/scrcpy", "-s", "DEVICE1", "--window-title", "NAME")
+        factory.create(device1) shouldBe listOf("test${fileSeparator}scrcpy", "-s", "DEVICE1", "--window-title", "NAME")
         factoryWhenNoSeparator.create(device1) shouldBe listOf(
-            "test/scrcpy",
+            "test${fileSeparator}scrcpy",
             "-s",
             "DEVICE1",
             "--window-title",
@@ -26,7 +27,7 @@ class ScrcpyCommandCreatorTest : StringSpec({
         )
         factory.create(device2) shouldBe
             listOf(
-                "test/scrcpy",
+                "test${fileSeparator}scrcpy",
                 "-s",
                 "DEVICE2",
                 "-m",
@@ -40,7 +41,7 @@ class ScrcpyCommandCreatorTest : StringSpec({
             )
         factoryWhenNoSeparator.create(device2) shouldBe
             listOf(
-                "test/scrcpy",
+                "test${fileSeparator}scrcpy",
                 "-s",
                 "DEVICE2",
                 "-m",
@@ -83,24 +84,24 @@ class ScrcpyCommandCreatorTest : StringSpec({
         )
     }
     "create_record" {
-        val factory = ScrcpyCommandCreator(path = "test/")
+        val factory = ScrcpyCommandCreator(path = "test")
         val factoryWhenNoSeparator = ScrcpyCommandCreator(path = "test")
 
         val device1 = Device.Context(
             Device(id = "DEVICE1", name = "NAME"), maxSize = null, maxFrameRate = null, bitrate = null
         )
         factory.createRecord(device1, "fileName1") shouldBe listOf(
-            "test/scrcpy", "-s", "DEVICE1", "--window-title", "NAME", "-r", "fileName1"
+            "test${fileSeparator}scrcpy", "-s", "DEVICE1", "--window-title", "NAME", "-r", "fileName1"
         )
         factoryWhenNoSeparator.createRecord(device1, "fileName1") shouldBe listOf(
-            "test/scrcpy", "-s", "DEVICE1", "--window-title", "NAME", "-r", "fileName1"
+            "test${fileSeparator}scrcpy", "-s", "DEVICE1", "--window-title", "NAME", "-r", "fileName1"
         )
 
         val device2 = Device.Context(
             Device(id = "DEVICE2", name = "NAME"), maxSize = 1000, maxFrameRate = 60, bitrate = 2
         )
         factory.createRecord(device2, "fileName2") shouldBe listOf(
-            "test/scrcpy",
+            "test${fileSeparator}scrcpy",
             "-s",
             "DEVICE2",
             "-m",
@@ -115,7 +116,7 @@ class ScrcpyCommandCreatorTest : StringSpec({
             "fileName2"
         )
         factoryWhenNoSeparator.createRecord(device2, "fileName2") shouldBe listOf(
-            "test/scrcpy",
+            "test${fileSeparator}scrcpy",
             "-s",
             "DEVICE2",
             "-m",
@@ -168,11 +169,11 @@ class ScrcpyCommandCreatorTest : StringSpec({
         )
     }
     "create_help" {
-        val factory = ScrcpyCommandCreator(path = "test/")
+        val factory = ScrcpyCommandCreator(path = "test${fileSeparator}")
         val factoryWhenNoSeparator = ScrcpyCommandCreator(path = "test")
 
-        factory.createHelp() shouldBe listOf("test/scrcpy", "-h")
-        factoryWhenNoSeparator.createHelp() shouldBe listOf("test/scrcpy", "-h")
+        factory.createHelp() shouldBe listOf("test${fileSeparator}scrcpy", "-h")
+        factoryWhenNoSeparator.createHelp() shouldBe listOf("test${fileSeparator}scrcpy", "-h")
     }
     "create_help_when_no_path_specified" {
         val factory = ScrcpyCommandCreator()


### PR DESCRIPTION
Changed to platform independent separator in tests so that devs can run tests on all platforms.

On Windows environments several of the command tests would fail as the "/" is not a separator "\" is as seen below.

![Windows tests](https://user-images.githubusercontent.com/14851039/200428916-c6f4f409-951c-47e5-ad1d-cb6fa24cc60a.PNG)

I tried to make this as tidy as possible by using a import alias.

Argument over if this is needed as CI will always be Linux, but worth considering.